### PR TITLE
7280 Allow changing global libzpool variables in zdb and ztest throug…

### DIFF
--- a/usr/src/uts/common/xen/io/xdf.c
+++ b/usr/src/uts/common/xen/io/xdf.c
@@ -596,8 +596,7 @@ xdf_cmlb_attach(xdf_t *vdp)
 	    B_TRUE,
 	    XD_IS_CD(vdp) ? DDI_NT_CD_XVMD : DDI_NT_BLOCK_XVMD,
 #if defined(XPV_HVM_DRIVER)
-	    (XD_IS_CD(vdp) ? 0 : CMLB_CREATE_ALTSLICE_VTOC_16_DTYPE_DIRECT) |
-	    CMLB_INTERNAL_MINOR_NODES,
+	    (XD_IS_CD(vdp) ? 0 : CMLB_CREATE_ALTSLICE_VTOC_16_DTYPE_DIRECT),
 #else /* !XPV_HVM_DRIVER */
 	    XD_IS_CD(vdp) ? 0 : CMLB_FAKE_LABEL_ONE_PARTITION,
 #endif /* !XPV_HVM_DRIVER */


### PR DESCRIPTION
…h command line

Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>

zdb is very handy for diagnosing problems with a pool in a safe and
quick way. When a pool is in a bad shape, we often want to disable some
fail-safes, or adjust some tunables in order to open them. In the
kernel, this is done by changing public variables in mdb. The goal of
this feature is to add the same capability to zdb and ztest, so that
they can change libzpool tuneables from the command line.

This patch enables the setting of ZFS global variables before running
zdb or ztest, replicating the functionality currently provided in the
kernel by mdb or /etc/system. This is done using new the "-o" option:

    $ zdb -o zfs_max_missing_tvds=1 -e -dd brokenpool

This example would set the boolean zfs_max_missing_tvds to TRUE before
executing the import of the pool, thus allowing zdb to analyze the
contents of a pool that is missing top-level devices.

Since dlsym is used to access the variable, there is no way to know the
size of the variable, hence by default we cast it as a 32-bit integer.
This should not be a problem for most tunables, as they are generally
either switches, or small numbers. For 64-bit numbers, we can still set
the lower 32-bits, however this wouldn't work on big-endian systems.

We could use CTF/ELF info to gather the size of the variable and then
cast it to the appropriate type, thus removing the limitations above.
However, this appears to be somewhat difficult, and the benefit of such
complexity is limited.

Upstream Bugs: DLPX-43356