### PR TITLE
7777 Expose xdf minor nodes when in PV-HVM mode

### DIFF
--- a/usr/src/uts/common/xen/io/xdf.c
+++ b/usr/src/uts/common/xen/io/xdf.c
@@ -596,8 +596,7 @@ xdf_cmlb_attach(xdf_t *vdp)
 	    B_TRUE,
 	    XD_IS_CD(vdp) ? DDI_NT_CD_XVMD : DDI_NT_BLOCK_XVMD,
 #if defined(XPV_HVM_DRIVER)
-	    (XD_IS_CD(vdp) ? 0 : CMLB_CREATE_ALTSLICE_VTOC_16_DTYPE_DIRECT) |
-	    CMLB_INTERNAL_MINOR_NODES,
+	    (XD_IS_CD(vdp) ? 0 : CMLB_CREATE_ALTSLICE_VTOC_16_DTYPE_DIRECT),
 #else /* !XPV_HVM_DRIVER */
 	    XD_IS_CD(vdp) ? 0 : CMLB_FAKE_LABEL_ONE_PARTITION,
 #endif /* !XPV_HVM_DRIVER */


### PR DESCRIPTION
Reviewed by: Jeremy Jones <jeremy@delphix.com>
Reviewed by: Basil Crow <basil.crow@delphix.com>

When in HVM mode the minor nodes of the xdf devices are hidden since the
xdf device is layered below an IDE disk device. In PV-HVM mode we have
disabled IDE devices and need to expose the xdf minor nodes in order for
devices to be visible in the device tree.

Upstream bugs: 34508